### PR TITLE
Recommenders 1.1.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,6 @@
-# upload_channels:
-#   - sfe1ed40
-# channels:
-#   - sfe1ed40
-
-channels:
-  - ari-test
+upload_channels:
   - sfe1ed40
+channels:
+  - sfe1ed40
+  
+upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,8 @@
-upload_channels:
-  - sfe1ed40
+# upload_channels:
+#   - sfe1ed40
+# channels:
+#   - sfe1ed40
+
 channels:
+  - ari-test
   - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40
-  
-upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,43 +2,25 @@
 {% set version = "1.1.1" %}
 
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
   sha256: 8db3785543b2ace6ddc68994e71c8920efa781432708d8d4cc7aff720f11b55f
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  skip: True  #[py<38 or py>310]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - bottleneck >=1.2.1,<2
-    - category_encoders >=1.3.0,<2
-    - cornac >=1.1.2,<2
-    - jinja2 >=2,<3.1
-    - lightfm >=1.15,<2
-    - lightgbm >=2.2.1
-    - matplotlib >=2.2.2,<4
-    - memory_profiler >=0.54.0,<1
-    - nltk >=3.4,<4
-    - numba >=0.38.1,<1
-    - numpy >=1.19
-    - pandas >1.0.3,<2
-    - pandera-core >=0.6.5
     - pip
     - python
-    - pyyaml >=5.4.1,<6
-    - requests >=2.0.0,<3
-    - retrying >=1.3.3
-    - scikit-learn >=0.22.1,<1.0.3
-    - scikit-surprise >=1.0.6
-    - scipy >=1.0.0,<2
-    - seaborn >=0.8.1,<1
-    - tqdm >=4.31.1,<5
-    - transformers >=2.5.0,<5
+    - setuptools
+    - wheel
+    - numpy {{ numpy }}
   run:
     - bottleneck >=1.2.1,<2
     - category_encoders >=1.3.0,<2
@@ -52,7 +34,7 @@ requirements:
     - numba >=0.38.1,<1
     - numpy >=1.19
     - pandas >1.0.3,<2
-    - pandera[strategies] >=0.6.5
+    - pandera-core >=0.6.5
     - python
     - pyyaml >=5.4.1,<6
     - requests >=2.0.0,<3
@@ -65,6 +47,10 @@ requirements:
     - transformers >=2.5.0,<5
 
 test:
+  requires:
+    - pip
+  commands:
+    - pip check
   imports:
     - recommenders
     - recommenders.datasets
@@ -99,14 +85,17 @@ test:
     - recommenders.utils
 
 about:
-  home: "https://github.com/microsoft/recommenders"
+  home: https://github.com/microsoft/recommenders
   license: MIT
   license_family: MIT
-  license_file:
-  summary: "Microsoft Recommenders - Python utilities for building recommender systems"
-  doc_url:
-  dev_url:
+  license_url: https://github.com/microsoft/recommenders/blob/main/LICENSE
+  description: |
+    This package contains functions to simplify common tasks used when
+    developing and evaluating recommender systems.
+  summary: Microsoft Recommenders - Python utilities for building recommender systems
+  doc_url: https://pypi.org/project/recommenders/
+  dev_url: https://github.com/microsoft/recommenders
 
 extra:
   recipe-maintainers:
-    - your-github-id-here
+    - Arishamays1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  #[py<38 or py>310]
+  skip: True  #[py<38 or py>310 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,112 @@
+{% set name = "recommenders" %}
+{% set version = "1.1.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 8db3785543b2ace6ddc68994e71c8920efa781432708d8d4cc7aff720f11b55f
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - bottleneck >=1.2.1,<2
+    - category_encoders >=1.3.0,<2
+    - cornac >=1.1.2,<2
+    - jinja2 >=2,<3.1
+    - lightfm >=1.15,<2
+    - lightgbm >=2.2.1
+    - matplotlib >=2.2.2,<4
+    - memory_profiler >=0.54.0,<1
+    - nltk >=3.4,<4
+    - numba >=0.38.1,<1
+    - numpy >=1.19
+    - pandas >1.0.3,<2
+    - pandera-core >=0.6.5
+    - pip
+    - python
+    - pyyaml >=5.4.1,<6
+    - requests >=2.0.0,<3
+    - retrying >=1.3.3
+    - scikit-learn >=0.22.1,<1.0.3
+    - scikit-surprise >=1.0.6
+    - scipy >=1.0.0,<2
+    - seaborn >=0.8.1,<1
+    - tqdm >=4.31.1,<5
+    - transformers >=2.5.0,<5
+  run:
+    - bottleneck >=1.2.1,<2
+    - category_encoders >=1.3.0,<2
+    - cornac >=1.1.2,<2
+    - jinja2 >=2,<3.1
+    - lightfm >=1.15,<2
+    - lightgbm >=2.2.1
+    - matplotlib >=2.2.2,<4
+    - memory_profiler >=0.54.0,<1
+    - nltk >=3.4,<4
+    - numba >=0.38.1,<1
+    - numpy >=1.19
+    - pandas >1.0.3,<2
+    - pandera[strategies] >=0.6.5
+    - python
+    - pyyaml >=5.4.1,<6
+    - requests >=2.0.0,<3
+    - retrying >=1.3.3
+    - scikit-learn >=0.22.1,<1.0.3
+    - scikit-surprise >=1.0.6
+    - scipy >=1.0.0,<2
+    - seaborn >=0.8.1,<1
+    - tqdm >=4.31.1,<5
+    - transformers >=2.5.0,<5
+
+test:
+  imports:
+    - recommenders
+    - recommenders.datasets
+    - recommenders.evaluation
+    - recommenders.models
+    - recommenders.models.cornac
+    - recommenders.models.deeprec
+    - recommenders.models.deeprec.DataModel
+    - recommenders.models.deeprec.io
+    - recommenders.models.deeprec.models
+    - recommenders.models.deeprec.models.graphrec
+    - recommenders.models.deeprec.models.sequential
+    - recommenders.models.fastai
+    - recommenders.models.geoimc
+    - recommenders.models.lightfm
+    - recommenders.models.lightgbm
+    - recommenders.models.ncf
+    - recommenders.models.newsrec
+    - recommenders.models.newsrec.io
+    - recommenders.models.newsrec.models
+    - recommenders.models.rbm
+    - recommenders.models.rlrmc
+    - recommenders.models.sar
+    - recommenders.models.sasrec
+    - recommenders.models.surprise
+    - recommenders.models.tfidf
+    - recommenders.models.vae
+    - recommenders.models.vowpal_wabbit
+    - recommenders.models.wide_deep
+    - recommenders.tuning
+    - recommenders.tuning.nni
+    - recommenders.utils
+
+about:
+  home: "https://github.com/microsoft/recommenders"
+  license: MIT
+  license_family: MIT
+  license_file:
+  summary: "Microsoft Recommenders - Python utilities for building recommender systems"
+  doc_url:
+  dev_url:
+
+extra:
+  recipe-maintainers:
+    - your-github-id-here

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - jinja2 >=2,<3.1
     - lightfm >=1.15,<2
     - lightgbm >=2.2.1
-    - matplotlib >=2.2.2,<4
+    - matplotlib-base >=2.2.2,<4
     - memory_profiler >=0.54.0,<1
     - nltk >=3.4,<4
     - numba >=0.38.1,<1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - seaborn >=0.8.1,<1
     - tqdm >=4.31.1,<5
     - transformers >=2.5.0,<5
-    - numpy>=1.19
+    - numpy >=1.19
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -93,7 +93,7 @@ about:
     This package contains functions to simplify common tasks used when
     developing and evaluating recommender systems.
   summary: Microsoft Recommenders - Python utilities for building recommender systems
-  doc_url: https://pypi.org/project/recommenders/
+  doc_url: https://microsoft-recommenders.readthedocs.io/
   dev_url: https://github.com/microsoft/recommenders
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - python
     - setuptools
     - wheel
-    - numpy >=1.19
+    - numpy 1.24.3
   run:
     - bottleneck >=1.2.1,<2
     - category_encoders >=1.3.0,<2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,32 +18,33 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - setuptools >=52
+    - wheel >=0.36
+    - numpy >=1.19
   run:
-    - bottleneck >=1.2.1,<2
-    - category_encoders >=1.3.0,<2
-    - cornac >=1.1.2,<2
-    - jinja2 >=2,<3.1
+    - python
+    - numpy >=1.19
+    - pandas >1.0.3,<2
+    - scipy >=1.0.0,<2
+    - tqdm >=4.31.1,<5
+    - matplotlib-base >=2.2.2,<4
+    - scikit-learn >=0.22.1,<1.0.3
+    - numba >=0.38.1,<1
     - lightfm >=1.15,<2
     - lightgbm >=2.2.1
-    - matplotlib-base >=2.2.2,<4
     - memory_profiler >=0.54.0,<1
     - nltk >=3.4,<4
-    - numba >=0.38.1,<1
-    - pandas >1.0.3,<2
-    - pandera-core >=0.6.5
-    - python
+    - seaborn >=0.8.1,<1
+    - transformers >=2.5.0,<5
+    - bottleneck >=1.2.1,<2
+    - category_encoders >=1.3.0,<2
+    - jinja2 >=2,<3.1
     - pyyaml >=5.4.1,<6
     - requests >=2.0.0,<3
+    - cornac >=1.1.2,<2
     - retrying >=1.3.3
-    - scikit-learn >=0.22.1,<1.0.3
+    - pandera-core >=0.6.5
     - scikit-surprise >=1.0.6
-    - scipy >=1.0.0,<2
-    - seaborn >=0.8.1,<1
-    - tqdm >=4.31.1,<5
-    - transformers >=2.5.0,<5
-    - numpy >=1.19
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  #[py<38 or py>310 or s390x]
+  skip: True  # [py<38 or py>=310 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - numpy {{ numpy }}
   run:
     - bottleneck >=1.2.1,<2
-    - category_encoders >=1.3.0,<2
+    - category_encoders >=1.3.0
     - cornac >=1.1.2,<2
     - jinja2 >=2,<3.1
     - lightfm >=1.15,<2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - python
     - setuptools
     - wheel
-    - numpy 1.24.3
   run:
     - bottleneck >=1.2.1,<2
     - category_encoders >=1.3.0,<2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  url: https://github.com/microsoft/recommenders/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: 8db3785543b2ace6ddc68994e71c8920efa781432708d8d4cc7aff720f11b55f
 
 build:
@@ -20,7 +20,7 @@ requirements:
     - python
     - setuptools
     - wheel
-    - numpy {{ numpy }}
+    - numpy >=1.19
   run:
     - bottleneck >=1.2.1,<2
     - category_encoders >=1.3.0
@@ -32,7 +32,6 @@ requirements:
     - memory_profiler >=0.54.0,<1
     - nltk >=3.4,<4
     - numba >=0.38.1,<1
-    - numpy >=1.19
     - pandas >1.0.3,<2
     - pandera-core >=0.6.5
     - python
@@ -45,6 +44,7 @@ requirements:
     - seaborn >=0.8.1,<1
     - tqdm >=4.31.1,<5
     - transformers >=2.5.0,<5
+    - {{ pin_compatible('numpy') }}
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - numpy >=1.19
   run:
     - bottleneck >=1.2.1,<2
-    - category_encoders >=1.3.0
+    - category_encoders >=1.3.0,<2
     - cornac >=1.1.2,<2
     - jinja2 >=2,<3.1
     - lightfm >=1.15,<2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - seaborn >=0.8.1,<1
     - tqdm >=4.31.1,<5
     - transformers >=2.5.0,<5
-    - {{ pin_compatible('numpy') }}
+    - numpy>=1.19
 
 test:
   requires:


### PR DESCRIPTION
## ☆ Recommenders 1.1.1 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2406)
[Upstream](https://github.com/microsoft/recommenders)
[Dependencies ](https://github.com/microsoft/recommenders/blob/main/setup.py)
# Changes
- Built package from scratch, incorporated necessary `dependencies`, `pinnings`, and `sha256`
- Due to `numba` availability, `s390x` has been skipped.
- Skipped  for python versions <3.8, and >=3.10.
- Adjusted `numpy`  pinning for compatibility with `numba`